### PR TITLE
release 1.3.1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.2.3
+appVersion: 1.3.1

--- a/templates/hcloud-csi.yml
+++ b/templates/hcloud-csi.yml
@@ -1,4 +1,4 @@
-# Imported from https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.2.3/deploy/kubernetes/hcloud-csi.yml.
+# Imported from https://raw.githubusercontent.com/hetznercloud/csi-driver/v1.3.1/deploy/kubernetes/hcloud-csi.yml.
 ---
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
@@ -51,11 +51,11 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "list"]
   - apiGroups: [""]
-    resources: ["persistentvolumes", "persistentvolumeclaims/status"]
+    resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "delete", "patch"]
   - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch", "update"]
+    resources: ["persistentvolumeclaims", "persistentvolumeclaims/status"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
@@ -103,12 +103,11 @@ spec:
       serviceAccountName: hcloud-csi
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v1.2.1
+          image: quay.io/k8scsi/csi-attacher:v2.2.0
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
             - --v=5
             - --leader-election
-            - --leader-election-type=leases
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -132,7 +131,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.3.1
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
           args:
             - --provisioner=csi.hetzner.cloud
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
@@ -167,11 +166,30 @@ spec:
           ports:
             - containerPort: 9189
               name: metrics
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
           securityContext:
             privileged: true
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
+        - name: liveness-probe
+          imagePullPolicy: Always
+          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          args:
+            - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
+          volumeMounts:
+            - mountPath: /var/lib/csi/sockets/pluginproxy/
+              name: socket-dir
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -194,7 +212,7 @@ spec:
       serviceAccount: hcloud-csi-node
       containers:
         - name: csi-node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -238,6 +256,25 @@ spec:
           ports:
             - containerPort: 9189
               name: metrics
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+        - name: liveness-probe
+          imagePullPolicy: Always
+          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          args:
+            - --csi-address=/csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: plugin-dir
       volumes:
         - name: kubelet-dir
           hostPath:

--- a/templates/hcloud-csi.yml
+++ b/templates/hcloud-csi.yml
@@ -106,7 +106,7 @@ spec:
           image: quay.io/k8scsi/csi-attacher:v2.2.0
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
-            - --v=5
+            - --v=4
             - --leader-election
           volumeMounts:
             - name: socket-dir
@@ -120,7 +120,7 @@ spec:
           image: quay.io/k8scsi/csi-resizer:v0.3.0
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
-            - --v=5
+            - --v=4
             - --leader-election
           volumeMounts:
             - name: socket-dir
@@ -136,7 +136,7 @@ spec:
             - --provisioner=csi.hetzner.cloud
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
             - --feature-gates=Topology=true
-            - --v=5
+            - --v=4
             - --enable-leader-election
             - --leader-election-type=leases
           volumeMounts:


### PR DESCRIPTION
Upgrade helm chart to use 1.3.1(latest release) hcloud-csi-driver. 

I add metadata "namespace"... @invidian why you not use "kube-system" namespace from original deployment yaml? 